### PR TITLE
Avoid cold starts for this API

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -395,6 +395,9 @@ Resources:
       Handler: no.unit.nva.customer.get.GetCustomerByOrgNumberHandler::handleRequest
       Runtime: java11
       MemorySize: 1408
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 3
+      AutoPublishAlias: live
       Environment:
         Variables:
           ALLOWED_ORIGIN: '*'


### PR DESCRIPTION
It is used by Cognito in critical login process.

Related by https://github.com/BIBSYSDEV/nva-cognito-post-authentication-trigger/pull/12 and https://unit.atlassian.net/browse/NP-1477